### PR TITLE
Enabling app insights request logging

### DIFF
--- a/src/sfa.Tl.Marketing.Communication/Program.cs
+++ b/src/sfa.Tl.Marketing.Communication/Program.cs
@@ -39,10 +39,7 @@ var siteConfiguration = builder.Configuration.LoadConfigurationOptions()
 
 builder.Services
     .AddSingleton(siteConfiguration)
-    .AddApplicationInsightsTelemetry(new ApplicationInsightsServiceOptions
-    {
-        EnableRequestTrackingTelemetryModule = false
-    });
+    .AddApplicationInsightsTelemetry();
 
 builder.Services.Configure<CookiePolicyOptions>(options =>
 {


### PR DESCRIPTION
Needed to remove the lines that disabled app insights requests in order to troubleshoot statuscake downtime alerts.