### PR TITLE
Migrate ARM Templates To Platform Building Blocks Repo

### DIFF
--- a/azure/marketingcommunications-environment.json
+++ b/azure/marketingcommunications-environment.json
@@ -40,7 +40,7 @@
         }
     },
     "variables": {
-        "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/operations-devops-deployment/master/ArmTemplates/",
+        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/master/ArmTemplates/",
         "uiAppName": "[concat(parameters('resourceNamePrefix'), '-web')]",
         "appInsightName": "[concat(parameters('resourceNamePrefix'), '-ai')]",
         "workerFunctionAppName": "[concat(parameters('resourceNamePrefix'), '-func-worker')]",
@@ -63,6 +63,12 @@
                 "parameters": {
                     "storageAccountName": {
                         "value": "[variables('storageAccountName')]"
+                    },
+                    "storageKind": {
+                        "value": "StorageV2"
+                    },
+                    "allowBlobPublicAccess": {
+                        "value": true
                     }
                 }
             }
@@ -84,7 +90,7 @@
                     "attachedService": {
                         "value": "[variables('uiAppName')]"
                     },
-                    "workspaceResourceId": {
+                    "logAnalyticsWorkspaceId": {
                         "value": "[reference(concat('log-analytics-workspace','-',parameters('environmentNameAbbreviation'))).outputs.fullyQualifiedResourceId.value]"
                     }
                 }
@@ -212,6 +218,9 @@
                     "appServicePlanResourceGroup": {
                         "value": "[parameters('sharedEnvResourceGroup')]"
                     },
+                    "systemAssignedIdentity": {
+                        "value": "None"
+                    },
                     "functionAppAppSettings": {
                         "value": [
                             {
@@ -257,7 +266,7 @@
                         ]
                     }
                 }
-            }
+                }
         }
         // // {
         // //     "apiVersion": "2017-05-10",
@@ -306,9 +315,9 @@
         //             },
         //             "serverName": {
         //                 "value": "[parameters('sharedSQLServerName')]"
-            //         }
-            //     }
-            // }
+        //         }
+        //     }
+        // }
         // }
     ],
     "outputs": {

--- a/azure/marketingcommunications-shared.json
+++ b/azure/marketingcommunications-shared.json
@@ -51,7 +51,7 @@
         }
     },
     "variables": {
-        "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/operations-devops-deployment/master/ArmTemplates/",
+        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/tl-platform-building-blocks/master/ArmTemplates/",
         "resourceNamePrefix": "[toLower(parameters('environmentNameAbbreviation'))]",
         // "sqlServerName": "[concat(variables('resourceNamePrefix'), '-shared-sql')]",
         "sharedStorageAccountName": "[replace(concat(variables('resourceNamePrefix'), 'sharedstr'), '-', '')]",
@@ -155,6 +155,12 @@
                 "parameters": {
                     "storageAccountName": {
                         "value": "[variables('sharedStorageAccountName')]"
+                    },
+                    "storageKind": {
+                        "value": "StorageV2"
+                    },
+                    "allowBlobPublicAccess": {
+                        "value": true
                     }
                 }
             }
@@ -204,7 +210,7 @@
             "properties": {
                 "mode": "Incremental",
                 "templateLink": {
-                    "uri": "[concat(variables('deploymentUrlBase'),'app-service-plan-ase.json')]",
+                    "uri": "[concat(variables('deploymentUrlBase'),'app-service-plan.json')]",
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
@@ -236,6 +242,12 @@
                 "parameters": {
                     "storageAccountName": {
                         "value": "[variables('configStorageAccountName')]"
+                    },
+                    "storageKind": {
+                        "value": "StorageV2"
+                    },
+                    "allowBlobPublicAccess": {
+                        "value": true
                     }
                 }
             }


### PR DESCRIPTION
Deployment template has been changed to point to the newer Platform Building Blocks repo that the rest of the services use. Minor changes have also been made to ensure that the current configuration stays the same, whilst also making sure that the app insights resources are correctly linked to their log analytic workspaces.

Also brings some minor security improvements such as enforcing HTTPS 2.0 & disabling FTP in web and function apps, as part of the default config in the Platform Building Blocks repo.