### PR TITLE
Rotate Storage Account Access Keys

### DIFF
--- a/azure/marketingcommunications-environment.json
+++ b/azure/marketingcommunications-environment.json
@@ -249,11 +249,11 @@
                             },
                             {
                                 "name": "AzureWebJobsStorage",
-                                "value": "[reference(concat('storage-account','-',parameters('environmentNameAbbreviation'))).outputs.storageConnectionString.value]"
+                                "value": "[reference(concat('storage-account','-',parameters('environmentNameAbbreviation'))).outputs.storageConnectionStringKey2.value]"
                             },
                             {
                                 "name": "AzureWebJobsDashboard",
-                                "value": "[reference(concat('storage-account','-',parameters('environmentNameAbbreviation'))).outputs.storageConnectionString.value]"
+                                "value": "[reference(concat('storage-account','-',parameters('environmentNameAbbreviation'))).outputs.storageConnectionStringKey2.value]"
                             },
                             {
                                 "name": "WEBSITE_TIME_ZONE",
@@ -335,7 +335,7 @@
         },
         "StorageConnectionString": {
             "type": "string",
-            "value": "[reference(concat('storage-account','-', parameters('environmentNameAbbreviation'))).outputs.storageConnectionString.value]"
+            "value": "[reference(concat('storage-account','-', parameters('environmentNameAbbreviation'))).outputs.storageConnectionStringKey2.value]"
         }
     }
 }

--- a/azure/marketingcommunications-shared.json
+++ b/azure/marketingcommunications-shared.json
@@ -294,11 +294,11 @@
         // },
         "sharedStorageConnectionString": {
             "type": "string",
-            "value": "[reference(concat('shared-storage-account','-', parameters('environmentNameAbbreviation'))).outputs.storageConnectionString.value]"
+            "value": "[reference(concat('shared-storage-account','-', parameters('environmentNameAbbreviation'))).outputs.storageConnectionStringKey2.value]"
         },
         "configStorageConnectionString": {
             "type": "string",
-            "value": "[reference(concat('config-storage-account','-', parameters('environmentNameAbbreviation'))).outputs.storageConnectionString.value]"
+            "value": "[reference(concat('config-storage-account','-', parameters('environmentNameAbbreviation'))).outputs.storageConnectionStringKey2.value]"
         },
         "ConfigStorageAccountName": {
             "type": "string",


### PR DESCRIPTION
This change updates storage account access key outputs in the ARM templates to support the rotation of the keys, by consuming the newly created key2 connection string output that is being constructed in the platform building blocks repository.