### PR TITLE
Add app service IP restrictions

### DIFF
--- a/azure/marketingcommunications-environment.json
+++ b/azure/marketingcommunications-environment.json
@@ -31,6 +31,9 @@
         },
         "courseDirectoryImportTrigger": {
             "type": "string"
+        },
+        "ipSecurityRestrictions": {
+            "type": "array"
         }
     },
     "variables": {
@@ -190,6 +193,12 @@
                     },
                     "certificateThumbprint": {
                         "value": "[reference(concat('ui-app-service-certificate','-',parameters('environmentNameAbbreviation'))).outputs.certificateThumbprint.value]"
+                    },
+                    "ipSecurityRestrictions": {
+                        "value": "[parameters('ipSecurityRestrictions')]"
+                    },
+                    "ipSecurityRestrictionsDefaultAction": {
+                        "value": "Deny"
                     }
                 }
             },

--- a/yaml/jobs/marketingcommunications-infrastructure-job.yml
+++ b/yaml/jobs/marketingcommunications-infrastructure-job.yml
@@ -47,6 +47,7 @@ jobs:
             -configStorageAccountName "$(ConfigStorageAccountName)"
             -uiCustomHostName "$(UICustomHostName)"
             -certificateName "$(CertificateName)"
-            -courseDirectoryImportTrigger "$(CourseDirectoryImportTrigger)"'
+            -courseDirectoryImportTrigger "$(CourseDirectoryImportTrigger)"
+            -ipSecurityRestrictions $(ipSecurityRestrictions)'
           tags: $(Tags)          
           processOutputs: true

--- a/yaml/stages/marketingcommunications-master-stage.yml
+++ b/yaml/stages/marketingcommunications-master-stage.yml
@@ -22,6 +22,8 @@ stages:
       environmentId: d01
       sharedEnvironmentId: d01
       serviceConnection: $(devServiceConnection)
+      variableTemplates: 
+        - ./Automation/variables/vars-non-prd.yml@devopsTemplates      
 ######################## TEST ##############################################
   - template: marketingcommunications-shared-stage.yml
     parameters:
@@ -41,7 +43,8 @@ stages:
       environmentId: t01
       sharedEnvironmentId: t01
       serviceConnection: $(testServiceConnection)
-
+      variableTemplates: 
+        - ./Automation/variables/vars-non-prd.yml@devopsTemplates
 ######################## Pre Prod ##############################################
   - template: marketingcommunications-shared-stage.yml
     parameters:
@@ -62,7 +65,8 @@ stages:
       environmentId: p02
       sharedEnvironmentId: p02
       serviceConnection: $(prodServiceConnection)
-
+      variableTemplates: 
+        - ./Automation/variables/vars-non-prd.yml@devopsTemplates
 # ######################## Prod ##############################################
   - template: marketingcommunications-shared-stage.yml
     parameters:
@@ -83,3 +87,5 @@ stages:
       environmentId: p01
       sharedEnvironmentId: p01
       serviceConnection: $(prodServiceConnection)
+      variableTemplates: 
+        - ./Automation/variables/vars-prd.yml@devopsTemplates

--- a/yaml/stages/marketingcommunications-stage.yml
+++ b/yaml/stages/marketingcommunications-stage.yml
@@ -11,6 +11,8 @@ parameters:
   type: string
 - name: serviceConnection
   type: string
+- name: variableTemplates
+  type: object
 
 stages:
 - stage: Deploy_${{parameters.environmentId}}
@@ -29,7 +31,8 @@ stages:
       value: ${{ parameters.environmentName }}
     - name: environmentTagName
       value: ${{parameters.environmentTagName}}
-      
+    - '${{ each variableTemplate in parameters.variableTemplates }}':
+      - template: '${{variableTemplate}}'      
       
   displayName: '${{parameters.environmentName}} [${{parameters.environmentId}}] deployment'
   jobs:  


### PR DESCRIPTION
Adds app service IP restrictions to only allow traffic from the prod or non prod WAF by taking the restriction rules from yaml templates, and setting the default action for unrecognised traffic to be deny.