### PR TITLE
Enable app service & function app health checks

### DIFF
--- a/azure/marketingcommunications-environment.json
+++ b/azure/marketingcommunications-environment.json
@@ -141,7 +141,7 @@
             }
         },
         {
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2022-09-01",
             "name": "[concat('ui-app-service','-', parameters('environmentNameAbbreviation'))]",
             "type": "Microsoft.Resources/deployments",
             "properties": {
@@ -189,6 +189,10 @@
                             {
                                 "name": "WEBSITE_ADD_SITENAME_BINDINGS_IN_APPHOST_CONFIG",
                                 "value": "1"
+                            },
+                            {
+                                "name": "WEBSITE_SWAP_WARMUP_PING_PATH",
+                                "value": "/health"
                             }
                         ]
                     },
@@ -203,6 +207,9 @@
                     },
                     "ipSecurityRestrictionsDefaultAction": {
                         "value": "Deny"
+                    },
+                    "healthCheckPath": {
+                        "value": "/health"
                     }
                 }
             },
@@ -232,6 +239,9 @@
                     },
                     "systemAssignedIdentity": {
                         "value": "SystemAssigned"
+                    },
+                    "healthCheckPath": {
+                        "value": "/api/healthcheck"
                     },
                     "functionAppAppSettings": {
                         "value": [
@@ -277,11 +287,11 @@
                             },
                             {
                                 "name": "WEBSITE_SWAP_WARMUP_PING_PATH",
-                                "value": "api/GetProviders"
+                                "value": "/api/healthcheck"
                             },
                             {
                                 "name": "WEBSITE_SWAP_WARMUP_PING_STATUSES",
-                                "value": "401"
+                                "value": "200"
                             },
                             {
                                 "name": "FUNCTIONS_WORKER_RUNTIME",

--- a/src/sfa.Tl.Marketing.Communication.Functions/HealthCheck.cs
+++ b/src/sfa.Tl.Marketing.Communication.Functions/HealthCheck.cs
@@ -17,7 +17,7 @@ public class HealthCheck
     }
 
     [Function("HealthCheck")]
-    public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Function, "get", Route = null)] HttpRequest req)
+    public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequest req)
     {
         try
         {

--- a/yaml/jobs/marketingcommunications-publish-site-job.yml
+++ b/yaml/jobs/marketingcommunications-publish-site-job.yml
@@ -65,10 +65,11 @@ jobs:
       SourceSlot: staging
 
   - task: AzureAppServiceManage@0
-    displayName: 'Delete swap Slot: $(uiAppName)'
+    displayName: 'Stop swap Slot: $(uiAppName)'
     inputs:
       azureSubscription: ${{ parameters.serviceConnection }}
-      Action: 'Delete Slot'
+      Action: 'Stop Azure App Service'
       WebAppName: '$(uiAppName)'
+      SpecifySlotOrASE: true
       ResourceGroupName: '$(ResourceGroupName)'
       Slot: 'staging'


### PR DESCRIPTION
- This change enables health checks for app services and function apps by setting the health check feature to ping the associated health endpoints. Additionally, it ensures that during pipeline deployments, healthy pings are received before performing slot swaps. 
- A minor change was made to the health check function code to ensure the correct auth level is used when attempting to ping the function.
- One final change was made to update the publish site pipeline job to ensure that the unused/staging slots of the app services are stopped instead of deleting them. Deletion of slots was causing the configuration that enables the health check to be removed and it would not stay permanently enabled. Changing the config to stop the slot rather than delete it also brings the pipeline configuration in line with the rest of the T Levels services. 