### PR TITLE
Cache NuGet Packages

### DIFF
--- a/yaml/jobs/marketingcommunications-build-application-job.yml
+++ b/yaml/jobs/marketingcommunications-build-application-job.yml
@@ -1,5 +1,7 @@
 jobs:
 - job: 'CodeBuild'
+  variables:
+    NUGET_PACKAGES: $(Pipeline.Workspace)/.nuget/packages
   pool:
       name: 'Azure Pipelines'
       vmImage: 'windows-latest'
@@ -39,12 +41,21 @@ jobs:
         packageType: 'sdk'
         version: '6.x'
 
+    - task: Cache@2
+      displayName: Cache
+      inputs:
+        key: 'nuget | "$(Agent.OS)" | src\Sfa.Tl.Marketing.Communication\package-lock.json'
+        restoreKeys: |
+          nuget | "$(Agent.OS)"
+          nuget
+        path: '$(NUGET_PACKAGES)'
+        cacheHitVar: 'CACHE_RESTORED'
+
     - task: DotNetCoreCLI@2
       displayName: 'DotNet Restore'
       inputs:
         command: restore
         projects: 'src/**/*.csproj'
-        noCache: true
 
     - task: DotNetCoreCLI@2
       displayName: 'DotNet Build'
@@ -58,7 +69,7 @@ jobs:
       inputs:
         command: test
         projects: '**/*.UnitTests.csproj'
-        arguments: '--configuration $(buildConfiguration)  --no-restore'
+        arguments: '--configuration $(buildConfiguration)  --no-build'
 
     - task: DotNetCoreCLI@2
       displayName: 'DotNet Publish'


### PR DESCRIPTION
This PR adds caching for NuGet packages which improves build performance by reducing redundant package restores.

**Changes:**

- Added task to cache NuGet packages using package-lock.json as the cache key.
- Defined NUGET_PACKAGES variable for the cache path.
- Removed noCache: true from the restore task to enable dependency caching.