### PR TITLE
Add Key Vault Config Automation to Pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,11 @@ resources:
       endpoint: DfE-Digital
       name: DFE-Digital/operations-devops-pipeline-templates
 
+    - repository: devopsTools
+      type: github
+      endpoint: DfE-Digital
+      name: DFE-Digital/operations-devops-tools
+
 trigger:
   branches:
     include: 

--- a/yaml/jobs/marketingcommunications-infrastructure-job.yml
+++ b/yaml/jobs/marketingcommunications-infrastructure-job.yml
@@ -43,3 +43,14 @@ jobs:
             -ipSecurityRestrictions $(ipSecurityRestrictions)'
           tags: $(Tags)          
           processOutputs: true
+
+      - task: AzurePowerShell@5
+        displayName: 'Set Certificate Policy'
+        inputs:
+          azureSubscription: ${{ parameters.serviceConnection }}
+          ScriptType: InlineScript
+          Inline: | 
+            Set-AzKeyVaultCertificatePolicy -VaultName $(SharedKeyVaultName) -Name $(CertificateName) -RenewAtNumberOfDaysBeforeExpiry 30
+          azurePowerShellVersion: LatestVersion
+
+

--- a/yaml/jobs/marketingcommunications-shared-infrastructure-job.yml
+++ b/yaml/jobs/marketingcommunications-shared-infrastructure-job.yml
@@ -7,6 +7,8 @@ parameters:
     type: string
   - name: environmentName
     type: string
+  - name: globalSignServiceAccountPassword
+    type: string
 jobs:
 
   - deployment: DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}
@@ -17,13 +19,14 @@ jobs:
         deploy:
           steps:
             - checkout: self
+            - checkout: devopsTools
             - template: ./Infrastructure/steps/deploy-template.yml@devopsTemplates
               parameters:
                 serviceConnection: ${{ parameters.serviceConnection }}
                 subscriptionId: $(subscriptionId)
                 resourceGroupName: $(SharedResourceGroup)
                 location: 'West Europe'
-                templateFilePath: './azure/marketingcommunications-shared.json'
+                templateFilePath: './tl-marketing-and-communication/azure/marketingcommunications-shared.json'
                 armParameterOverrideString: '-environmentNameAbbreviation "${{parameters.baseName}}" 
                   -appServicePlanTier "$(AppServicePlanTier)"
                   -appServicePlanSize "$(AppServicePlanSize)"
@@ -49,3 +52,15 @@ jobs:
                   }
                 azurePowerShellVersion: LatestVersion
                 pwsh: true
+
+            - task: AzurePowerShell@5
+              displayName: 'Set Certificate Issuer and Contacts'
+              inputs:
+                azureSubscription: ${{ parameters.serviceConnection }}
+                ScriptType: 'FilePath'
+                ScriptPath: './operations-devops-tools/Powershell/SetKeyVaultConfig/SetKeyVaultConfig.ps1'
+                ScriptArguments: '-SharedKeyVaultName "$(armOutputs.armoutput.sharedKeyVaultName)" -GlobalSignServiceAccountId $(GlobalSignServiceAccountId) -KvContactEmailAddress $(KvContactEmailAddress) -CaAdminFirstName $(CaAdminFirstName) -CaAdminLastName $(CaAdminLastName) -CaAdminEmailAddress $(CaAdminEmailAddress)'
+                FailOnStandardError: true
+                azurePowerShellVersion: LatestVersion
+              env: 
+                globalSignServiceAccountPassword: $(GlobalSignServiceAccountPassword)

--- a/yaml/stages/marketingcommunications-master-stage.yml
+++ b/yaml/stages/marketingcommunications-master-stage.yml
@@ -23,7 +23,7 @@ stages:
       sharedEnvironmentId: d01
       serviceConnection: $(devServiceConnection)
       variableTemplates: 
-        - ./Automation/variables/vars-non-prd.yml@devopsTemplates      
+        - ./Automation/variables/vars-non-prd.yml@devopsTemplates   
 ######################## TEST ##############################################
   - template: marketingcommunications-shared-stage.yml
     parameters:

--- a/yaml/stages/marketingcommunications-shared-stage.yml
+++ b/yaml/stages/marketingcommunications-shared-stage.yml
@@ -17,6 +17,7 @@ stages:
       - '${{dependency}}'
   variables:
     - group: platform-global-marcom
+    - group: platform-global
     - group: platform-${{parameters.environmentName}}
     - group: platform-${{parameters.environmentName}}-marcom
     - name: SharedBaseName
@@ -36,3 +37,4 @@ stages:
       serviceConnection: ${{ parameters.serviceConnection }}
       sharedEnvironmentId: ${{ parameters.sharedEnvironmentId }}
       environmentName: ${{parameters.environmentName}}
+      globalSignServiceAccountPassword: $($GlobalSignServiceAccountPassword)


### PR DESCRIPTION
This pull request adds tasks to automate the configuration of Key Vault certificates and issuer settings.

**Changes**


- Adds a task to configure the certificate issuer/CA and contact information for Key Vault by utilising a PowerShell script from the DevOps Tools repo (https://github.com/DFE-Digital/operations-devops-tools/pull/31)
- Adds a task to update the certificate renewal policy for certificates to auto renew at 30 days expiry