### PR TITLE
Update Generate Config Task

### DIFF
--- a/yaml/jobs/marketingcommunications-generate-configs-job.yml
+++ b/yaml/jobs/marketingcommunications-generate-configs-job.yml
@@ -6,6 +6,11 @@ parameters:
   - name: tableName
     type: string
     default: 'configuration'
+  - name: environmentName
+    type: string
+  - name: ConfigurationSecrets
+    type: object
+    default: {}
 jobs:
 - job: GenerateConfigs
   variables:
@@ -20,6 +25,8 @@ jobs:
   dependsOn:
     - DeployMarketingCommunicationsInfrastructure
   steps:
+    - checkout: self
+    - checkout: devopsTools
     - task: DownloadBuildArtifacts@0
       inputs:
         buildType: 'current'
@@ -27,10 +34,20 @@ jobs:
         artifactName: 'drop'
         downloadPath: '$(System.ArtifactsDirectory)'
 
-    - task: GenerateEnvironmentConfiguration@3
-      displayName: 'Process schemas in $(System.ArtifactsDirectory)/drop/config'
+    - task: AzurePowerShell@5
+      displayName: 'Generate Configuration'
       inputs:
-        SourcePath: '$(System.ArtifactsDirectory)/drop/config'
-        ServiceConnectionName: ${{ parameters.serviceConnection}}
-        StorageAccountName: '$(ConfigStorageAccountName)'
-        TableName: Configuration
+        azureSubscription: ${{ parameters.ServiceConnection }}
+        ScriptType: 'FilePath'
+        scriptPath: './operations-devops-tools/Powershell/GenerateConfig/New-ConfigurationTableEntry.ps1'
+        scriptArguments:
+          -SourcePath "$(System.ArtifactsDirectory)/drop/config"
+          -TargetFilename "Sfa.Tl.Marketing.Communication.schema.json"
+          -StorageAccountName "$(ConfigStorageAccountName)"
+          -StorageAccountResourceGroup "$(SharedResourceGroup)"
+          -EnvironmentName ${{ parameters.environmentName }}
+          -TableName "Configuration"
+        azurePowerShellVersion: LatestVersion
+        pwsh: true
+        FailOnStandardError: true
+      env: ${{ parameters.ConfigurationSecrets }}

--- a/yaml/jobs/marketingcommunications-publish-site-job.yml
+++ b/yaml/jobs/marketingcommunications-publish-site-job.yml
@@ -34,7 +34,7 @@ jobs:
   #     package: '$(System.ArtifactsDirectory)/drop/Sfa.Tl.Marketing.Communications.Web.zip'
   #     deploymentMethod: 'auto'
 
-  - task: AzureRmWebAppDeployment@4
+  - task: AzureRmWebAppDeployment@3
     displayName: 'Azure App Service Deploy: $(uiAppName)'
     inputs:
       azureSubscription: ${{ parameters.serviceConnection }}

--- a/yaml/stages/marketingcommunications-master-stage.yml
+++ b/yaml/stages/marketingcommunications-master-stage.yml
@@ -22,6 +22,7 @@ stages:
       environmentId: d01
       sharedEnvironmentId: d01
       serviceConnection: $(devServiceConnection)
+      applicationName: mcom
       variableTemplates: 
         - ./Automation/variables/vars-non-prd.yml@devopsTemplates   
 ######################## TEST ##############################################
@@ -43,6 +44,7 @@ stages:
       environmentId: t01
       sharedEnvironmentId: t01
       serviceConnection: $(testServiceConnection)
+      applicationName: mcom
       variableTemplates: 
         - ./Automation/variables/vars-non-prd.yml@devopsTemplates
 ######################## Pre Prod ##############################################
@@ -65,6 +67,7 @@ stages:
       environmentId: p02
       sharedEnvironmentId: p02
       serviceConnection: $(prodServiceConnection)
+      applicationName: mcom
       variableTemplates: 
         - ./Automation/variables/vars-non-prd.yml@devopsTemplates
 # ######################## Prod ##############################################
@@ -87,5 +90,6 @@ stages:
       environmentId: p01
       sharedEnvironmentId: p01
       serviceConnection: $(prodServiceConnection)
+      applicationName: mcom
       variableTemplates: 
         - ./Automation/variables/vars-prd.yml@devopsTemplates

--- a/yaml/stages/marketingcommunications-stage.yml
+++ b/yaml/stages/marketingcommunications-stage.yml
@@ -13,6 +13,8 @@ parameters:
   type: string
 - name: variableTemplates
   type: object
+- name: applicationName
+  type: string
 
 stages:
 - stage: Deploy_${{parameters.environmentId}}
@@ -32,7 +34,11 @@ stages:
     - name: environmentTagName
       value: ${{parameters.environmentTagName}}
     - '${{ each variableTemplate in parameters.variableTemplates }}':
-      - template: '${{variableTemplate}}'      
+      - template: '${{variableTemplate}}'
+    - name: SharedBaseName
+      value: "s126${{parameters.sharedEnvironmentId}}-${{parameters.applicationName}}"
+    - name: SharedResourceGroup
+      value: '$(SharedBaseName)-shared'   
       
   displayName: '${{parameters.environmentName}} [${{parameters.environmentId}}] deployment'
   jobs:  
@@ -47,6 +53,10 @@ stages:
     parameters:
       serviceConnection: ${{ parameters.serviceConnection }}
       sharedEnvironmentId: ${{ parameters.sharedEnvironmentId }}
+      environmentName: ${{parameters.environmentName}}
+      ConfigurationSecrets:
+        CourseDirectoryApiSettings_ApiKey: $(CourseDirectoryApiSettings_ApiKey)
+
 
   - template: ../jobs/marketingcommunications-publish-site-job.yml
     parameters:


### PR DESCRIPTION
The old custom pipeline task which generates application config was using depreciated PowerShell modules, so the task has been replaced with PowerShell scripts. The scripts have pulled directly from AS and have only had a small modification to ensure the required modules are installed due to T Levels not using custom images for the self-hosted agents.

PR for the scripts being added can be found here: https://github.com/DFE-Digital/operations-devops-tools/pull/32

Additionally, the AzureRmWebAppDeployment task has been reverted to version 3 due to the later version causing intermittent issues with app service slot swapping.