### PR TITLE
Disable Blob Storage Public Access

### DIFF
--- a/azure/marketingcommunications-environment.json
+++ b/azure/marketingcommunications-environment.json
@@ -62,9 +62,6 @@
                     "storageKind": {
                         "value": "StorageV2"
                     },
-                    "allowBlobPublicAccess": {
-                        "value": true
-                    },
                     "minimumTlsVersion": {
                         "value": "TLS1_2"
                     }

--- a/azure/marketingcommunications-shared.json
+++ b/azure/marketingcommunications-shared.json
@@ -143,9 +143,6 @@
                     "storageKind": {
                         "value": "StorageV2"
                     },
-                    "allowBlobPublicAccess": {
-                        "value": true
-                    },
                     "minimumTlsVersion": {
                         "value": "TLS1_2"
                     }
@@ -194,9 +191,6 @@
                     },
                     "storageKind": {
                         "value": "StorageV2"
-                    },
-                    "allowBlobPublicAccess": {
-                        "value": true
                     },
                     "minimumTlsVersion": {
                         "value": "TLS1_2"


### PR DESCRIPTION
Disabling as part of ITHC recommendations, also brings the config in line with the rest of the T Levels services as this config is set to be deny by default at the template level.