### PR TITLE
Add Variable Config for KV Secret Migration

### DIFF
--- a/yaml/stages/marketingcommunications-stage.yml
+++ b/yaml/stages/marketingcommunications-stage.yml
@@ -25,6 +25,7 @@ stages:
     - group: platform-global-marcom
     - group: platform-${{parameters.environmentName}}
     - group: platform-${{parameters.environmentName}}-marcom
+    - group: platform-${{parameters.environmentName}}-marcom-kv
     - name: BaseName
       value: "s126${{parameters.environmentId}}-mcom-${{parameters.environmentName}}"
     - name: ResourceGroupName
@@ -55,7 +56,8 @@ stages:
       sharedEnvironmentId: ${{ parameters.sharedEnvironmentId }}
       environmentName: ${{parameters.environmentName}}
       ConfigurationSecrets:
-        CourseDirectoryApiSettings_ApiKey: $(CourseDirectoryApiSettings_ApiKey)
+        CourseDirectoryApiSettings_ApiKey: $(CourseDirectoryApiSettingsApiKey)
+        GoogleMapsApiKey: $(GoogleMapsApiKey)
 
 
   - template: ../jobs/marketingcommunications-publish-site-job.yml


### PR DESCRIPTION
This PR updates the configuration needed to migrate secrets from pipeline variable groups to Key Vaults. It ensures that secrets are now retrieved from Key Vaults (which are linked to new variable groups).