### PR TITLE
Add Variable Config For KV Secret Migration

### DIFF
--- a/config/Sfa.Tl.Marketing.Communication.schema.json
+++ b/config/Sfa.Tl.Marketing.Communication.schema.json
@@ -17,7 +17,7 @@
         "ApiKey": {
           "minLength": 1,
           "type": "string",
-          "environmentVariable": "CourseDirectoryApiSettings_ApiKey"
+          "environmentVariable": "CourseDirectoryApiSettingsApiKey"
         }
       },
       "additionalProperties": false,

--- a/yaml/stages/marketingcommunications-stage.yml
+++ b/yaml/stages/marketingcommunications-stage.yml
@@ -25,6 +25,7 @@ stages:
     - group: platform-global-marcom
     - group: platform-${{parameters.environmentName}}
     - group: platform-${{parameters.environmentName}}-marcom
+    - group: platform-${{parameters.environmentName}}-marcom-kv
     - name: BaseName
       value: "s126${{parameters.environmentId}}-mcom-${{parameters.environmentName}}"
     - name: ResourceGroupName
@@ -55,7 +56,8 @@ stages:
       sharedEnvironmentId: ${{ parameters.sharedEnvironmentId }}
       environmentName: ${{parameters.environmentName}}
       ConfigurationSecrets:
-        CourseDirectoryApiSettings_ApiKey: $(CourseDirectoryApiSettings_ApiKey)
+        CourseDirectoryApiSettingsApiKey: $(CourseDirectoryApiSettingsApiKey)
+        GoogleMapsApiKey: $(GoogleMapsApiKey)
 
 
   - template: ../jobs/marketingcommunications-publish-site-job.yml


### PR DESCRIPTION
This PR updates YAML configuration that is required to migrate secrets from pipeline variable groups to Key Vaults. It ensures that secrets are now stored in Key Vaults instead of directly in variable groups.