### PR TITLE
Update Windows Server 2019 to Latest in ADO Pipelines

### DIFF
--- a/yaml/jobs/marketingcommunications-infrastructure-job.yml
+++ b/yaml/jobs/marketingcommunications-infrastructure-job.yml
@@ -11,7 +11,7 @@ jobs:
   - job: DeployMarketingCommunicationsInfrastructure
     pool:
       name: 'Azure Pipelines'
-      vmImage: 'windows-2019'
+      vmImage: 'windows-latest'
     variables:
       SharedASPName: $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.sharedASPName'] ]
       SharedKeyVaultName: $[ stageDependencies.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.outputs['DeploySharedInfrastructure_${{parameters.sharedEnvironmentId}}.armOutputs.armOutput.sharedKeyVaultName'] ]

--- a/yaml/jobs/marketingcommunications-post-deployment-job.yml
+++ b/yaml/jobs/marketingcommunications-post-deployment-job.yml
@@ -2,7 +2,7 @@ jobs:
   - job: PostDeployment
     pool:
         name: 'Azure Pipelines'
-        vmImage: 'windows-2019'
+        vmImage: 'windows-latest'
     dependsOn: 
     - PublishSite
     - PublishFunction


### PR DESCRIPTION
Update ADO pipelines to use latest supported Windows Server images, replacing deprecated 2019 version.