### PR TITLE
TL2023-1074: Remove bullet point from Building Services Engineering subject

### DIFF
--- a/src/sfa.Tl.Marketing.Communication/Views/Student/Subjects/BuildingServicesEngineering.cshtml
+++ b/src/sfa.Tl.Marketing.Communication/Views/Student/Subjects/BuildingServicesEngineering.cshtml
@@ -168,7 +168,6 @@
                     <div class="tl-subjects--accordion--panel">
                         <p>In addition to the core content, each student must choose one of the following specialisms:</p>
                         <ul class="tl-list--bullet">
-                            <li>electrical and electronic equipment engineering</li>
                             <li>electrotechnical engineering</li>
                             <li>gas engineering</li>
                             <li>protection systems engineering</li>


### PR DESCRIPTION
- Remove 'electrical and electronic equipment engineering' bullet point from specialism section of Building Services Engineering T Level